### PR TITLE
Parallelize prepare_data.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ data/
 predictions/
 processed_data/
 invoices/
+
+**/.vscode/
+*.swp
+**/*.egg-info/
+venv-*/

--- a/prepare_data.py
+++ b/prepare_data.py
@@ -17,16 +17,65 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import multiprocessing as mp
 
-import os
-import glob
 import argparse
+import glob
+import os
 import pdf2image
 import simplejson
-from tqdm import tqdm
+import tqdm
 
 from invoicenet import FIELDS, FIELD_TYPES
 from invoicenet.common import util
+
+
+def process_file(filename, out_dir, phase):
+    try:
+        page = pdf2image.convert_from_path(filename)[0]
+        page.save(os.path.join(out_dir, phase, os.path.basename(filename)[:-3] + 'png'))
+
+        height = page.size[1]
+        width = page.size[0]
+
+        ngrams = util.create_ngrams(page)
+        for ngram in ngrams:
+            if "amount" in ngram["parses"]:
+                ngram["parses"]["amount"] = util.normalize(ngram["parses"]["amount"], key="amount")
+            if "date" in ngram["parses"]:
+                ngram["parses"]["date"] = util.normalize(ngram["parses"]["date"], key="date")
+
+        with open(filename[:-3] + 'json', 'r') as fp:
+            labels = simplejson.loads(fp.read())
+
+        fields = {}
+        for field in FIELDS:
+            if field in labels:
+                if FIELDS[field] == FIELD_TYPES["amount"]:
+                    fields[field] = util.normalize(labels[field], key="amount")
+                elif FIELDS[field] == FIELD_TYPES["date"]:
+                    fields[field] = util.normalize(labels[field], key="date")
+                else:
+                    fields[field] = labels[field]
+            else:
+                fields[field] = ''
+
+        data = {
+            "fields": fields,
+            "nGrams": ngrams,
+            "height": height,
+            "width": width,
+            "filename": os.path.abspath(
+                os.path.join(out_dir, phase, os.path.basename(filename)[:-3] + 'png'))
+        }
+
+        with open(os.path.join(out_dir, phase, os.path.basename(filename)[:-3] + 'json'), 'w') as fp:
+            fp.write(simplejson.dumps(data, indent=2))
+        return True
+
+    except Exception as exp:
+        print("Skipping {} : {}".format(filename, exp))
+        return False
 
 
 def main():
@@ -57,51 +106,8 @@ def main():
     for phase, filenames in [('train', train_files), ('val', val_files)]:
         print("Preparing {} data...".format(phase))
 
-        for filename in tqdm(filenames):
-            try:
-                page = pdf2image.convert_from_path(filename)[0]
-                page.save(os.path.join(args.out_dir, phase, os.path.basename(filename)[:-3] + 'png'))
-
-                height = page.size[1]
-                width = page.size[0]
-
-                ngrams = util.create_ngrams(page)
-                for ngram in ngrams:
-                    if "amount" in ngram["parses"]:
-                        ngram["parses"]["amount"] = util.normalize(ngram["parses"]["amount"], key="amount")
-                    if "date" in ngram["parses"]:
-                        ngram["parses"]["date"] = util.normalize(ngram["parses"]["date"], key="date")
-
-                with open(filename[:-3] + 'json', 'r') as fp:
-                    labels = simplejson.loads(fp.read())
-
-                fields = {}
-                for field in FIELDS:
-                    if field in labels:
-                        if FIELDS[field] == FIELD_TYPES["amount"]:
-                            fields[field] = util.normalize(labels[field], key="amount")
-                        elif FIELDS[field] == FIELD_TYPES["date"]:
-                            fields[field] = util.normalize(labels[field], key="date")
-                        else:
-                            fields[field] = labels[field]
-                    else:
-                        fields[field] = ''
-
-                data = {
-                    "fields": fields,
-                    "nGrams": ngrams,
-                    "height": height,
-                    "width": width,
-                    "filename": os.path.abspath(
-                        os.path.join(args.out_dir, phase, os.path.basename(filename)[:-3] + 'png'))
-                }
-
-                with open(os.path.join(args.out_dir, phase, os.path.basename(filename)[:-3] + 'json'), 'w') as fp:
-                    fp.write(simplejson.dumps(data, indent=2))
-
-            except Exception as exp:
-                print("Skipping {} : {}".format(filename, exp))
-                continue
+        for filename in tqdm.tqdm(filenames):
+            process_file(filename, args.out_dir, phase)
 
 
 if __name__ == '__main__':

--- a/prepare_data.py
+++ b/prepare_data.py
@@ -87,6 +87,8 @@ def main():
                     help="path to save prepared data")
     ap.add_argument("--val_size", type=float, default=0.2,
                     help="validation split ration")
+    ap.add_argument("--cores", type=int, help='Number of virtual cores to parallelize over',
+                    default=max(1, (mp.cpu_count() - 2) / 2)) # To prevent IPC issues
 
     args = ap.parse_args()
 
@@ -107,7 +109,7 @@ def main():
         print("Preparing {} data...".format(phase))
 
         with tqdm.tqdm(total=len(filenames)) as pbar:
-            pool = mp.Pool(3)
+            pool = mp.Pool(args.cores)
             for filename in filenames:
                 pool.apply_async(process_file, args=(filename, args.out_dir, phase),
                                  callback=lambda _: pbar.update())

--- a/prepare_data.py
+++ b/prepare_data.py
@@ -106,8 +106,14 @@ def main():
     for phase, filenames in [('train', train_files), ('val', val_files)]:
         print("Preparing {} data...".format(phase))
 
-        for filename in tqdm.tqdm(filenames):
-            process_file(filename, args.out_dir, phase)
+        with tqdm.tqdm(total=len(filenames)) as pbar:
+            pool = mp.Pool(3)
+            for filename in filenames:
+                pool.apply_async(process_file, args=(filename, args.out_dir, phase),
+                                 callback=lambda _: pbar.update())
+
+            pool.close()
+            pool.join()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When I initially ran `prepare_data.py` on my folder of ~500 PDFs, it took 31:49, which is concerning when considering potentially much larger data sets.

Since each file is essentially being processed in isolation, this should be parallelizable with basically no problems. This PR splits up the `filenames` so that they are processed at the same time over `n` cores. Through empirical results, it seems as if `prepare_data.py` requires roughly ~1.5-2 cores of processing power for any given filename. That means that `n` *cannot* equal the number of logical cores and the overhead in python's interprocess communications (IPC) causes a significant slow down (I had gotten 4x slowdown on my machine).

Therefore, I'm calculating `n` as `n = (# of cores - 2) / 2`. Basically dedicate all cores in your machine to the task (as two cores correspond to one filename) and reserve two for the system / Python. Note that `n` can't go below 1. I haven't been able to get decent results by ever setting `n` to be more than this value.

#### Results
As mentioned before, when I ran the current `prepare_data.py` on ~500 PDFs, it took 31:49. When I ran the parallelized version in this PR on my computer (Intel i7 6700k--4 physical cores, 8 logical cores) and `n=3`, it finished in 9:57. Therefore, I had achieved a **~3x speed up** on my machine. I'm sure that better results could be achieved with newer processors / more cores.